### PR TITLE
Harden internals before tagging

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test
+name: CI
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Home Assistant MTA Subway
 
-[![Test](https://github.com/iicky/homeassistant-mta-subway/actions/workflows/test.yml/badge.svg)](https://github.com/iicky/homeassistant-mta-subway/actions/workflows/test.yml)
-[![hassfest](https://github.com/iicky/homeassistant-mta-subway/actions/workflows/hassfest.yml/badge.svg)](https://github.com/iicky/homeassistant-mta-subway/actions/workflows/hassfest.yml)
-[![HACS Validate](https://github.com/iicky/homeassistant-mta-subway/actions/workflows/hacs_validate.yml/badge.svg)](https://github.com/iicky/homeassistant-mta-subway/actions/workflows/hacs_validate.yml)
-[![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/hacs/integration)
+[![CI](https://github.com/iicky/homeassistant-mta-subway/actions/workflows/test.yml/badge.svg)](https://github.com/iicky/homeassistant-mta-subway/actions/workflows/test.yml)
+[![codecov](https://codecov.io/gh/iicky/homeassistant-mta-subway/graph/badge.svg)](https://codecov.io/gh/iicky/homeassistant-mta-subway)
+[![HACS](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/hacs/integration)
 
 > **Disclaimer:** This is an unofficial, community-maintained integration. It is not affiliated with, endorsed by, or sponsored by the Metropolitan Transportation Authority (MTA). The MTA logo and subway bullet icons are used for identification purposes only.
 

--- a/custom_components/mta_subway/__init__.py
+++ b/custom_components/mta_subway/__init__.py
@@ -6,15 +6,17 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from homeassistant.components.http import StaticPathConfig
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 
-from .const import DOMAIN, ICONS_BASE
+from .const import ICONS_BASE
 from .coordinator import MTAAlertsCoordinator, MTASubwayCoordinator, MTASubwayData
 
 if TYPE_CHECKING:
-    from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.typing import ConfigType
+
+type MTASubwayConfigEntry = ConfigEntry[MTASubwayData]
 
 PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BINARY_SENSOR]
 
@@ -29,29 +31,26 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: MTASubwayConfigEntry) -> bool:
     """Set up MTA Subway from a config entry."""
     routes = MTASubwayCoordinator(hass)
     alerts = MTAAlertsCoordinator(hass)
     await routes.async_config_entry_first_refresh()
     await alerts.async_config_entry_first_refresh()
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = MTASubwayData(
-        routes=routes, alerts=alerts
-    )
+    entry.runtime_data = MTASubwayData(routes=routes, alerts=alerts)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: MTASubwayConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id, None)
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
-async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+async def _async_update_listener(
+    hass: HomeAssistant, entry: MTASubwayConfigEntry
+) -> None:
     """Reload the entry when options change."""
     await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/mta_subway/binary_sensor.py
+++ b/custom_components/mta_subway/binary_sensor.py
@@ -21,13 +21,17 @@ from .const import (
     CONF_LINE,
     DOMAIN,
 )
-from .coordinator import MTAAlertsCoordinator, MTASubwayData
+from .coordinator import MTAAlertsCoordinator
 from .models import AlertEntity
 
 if TYPE_CHECKING:
-    from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+    from . import MTASubwayConfigEntry
+
+
+PARALLEL_UPDATES = 0
 
 
 PLANNED_WORK_TYPES = frozenset({"Planned Work"})
@@ -59,11 +63,11 @@ def _classify(alert_type: str | None) -> str:
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: MTASubwayConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up alert binary sensors from a config entry."""
-    data: MTASubwayData = hass.data[DOMAIN][entry.entry_id]
+    data = entry.runtime_data
     lines: list[str] = entry.options.get(CONF_LINE) or entry.data[CONF_LINE]
     async_add_entities(
         MTAAlertBinarySensor(data.alerts, line, category)

--- a/custom_components/mta_subway/diagnostics.py
+++ b/custom_components/mta_subway/diagnostics.py
@@ -1,0 +1,54 @@
+"""Diagnostics support for the MTA Subway integration."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+    from . import MTASubwayConfigEntry
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant,
+    entry: MTASubwayConfigEntry,
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    data = entry.runtime_data
+    routes = data.routes.data or {}
+    alerts = data.alerts.data or []
+
+    return {
+        "config_entry": {
+            "data": dict(entry.data),
+            "options": dict(entry.options),
+        },
+        "routes": {
+            "last_update_success": data.routes.last_update_success,
+            "last_exception": str(data.routes.last_exception)
+            if data.routes.last_exception
+            else None,
+            "count": len(routes),
+            "lines": sorted(routes.keys()),
+            "sample": (routes[next(iter(routes))].model_dump() if routes else None),
+        },
+        "alerts": {
+            "last_update_success": data.alerts.last_update_success,
+            "last_exception": str(data.alerts.last_exception)
+            if data.alerts.last_exception
+            else None,
+            "count": len(alerts),
+            "alert_types": sorted(
+                {a.alert.alert_type for a in alerts if a.alert.alert_type}
+            ),
+            "by_route": {
+                route_id: sum(
+                    1
+                    for a in alerts
+                    if any(ie.route_id == route_id for ie in a.alert.informed_entity)
+                )
+                for route_id in sorted(routes.keys())
+            },
+        },
+    }

--- a/custom_components/mta_subway/models.py
+++ b/custom_components/mta_subway/models.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, ConfigDict, Field
 class DirectionalStatus(BaseModel):
     """Per-direction string values keyed by north / south."""
 
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="ignore", frozen=True)
 
     north: str | None = None
     south: str | None = None
@@ -17,7 +17,7 @@ class DirectionalStatus(BaseModel):
 class ServiceChangeSummary(BaseModel):
     """Service-change summary lists keyed by direction or `both`."""
 
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="ignore", frozen=True)
 
     both: list[str] = Field(default_factory=list)
     north: list[str] = Field(default_factory=list)
@@ -27,7 +27,7 @@ class ServiceChangeSummary(BaseModel):
 class Route(BaseModel):
     """Service status for a single subway line."""
 
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="ignore", frozen=True)
 
     id: str
     name: str
@@ -43,7 +43,7 @@ class Route(BaseModel):
 class SubwayResponse(BaseModel):
     """Top-level response from subwaynow.app /routes?detailed=1."""
 
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="ignore", frozen=True)
 
     routes: dict[str, Route]
 
@@ -51,7 +51,7 @@ class SubwayResponse(BaseModel):
 class TimeRange(BaseModel):
     """An alert's active time window in UNIX seconds."""
 
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="ignore", frozen=True)
 
     start: int | None = None
     end: int | None = None
@@ -60,7 +60,7 @@ class TimeRange(BaseModel):
 class InformedEntity(BaseModel):
     """A route, stop, or trip an alert applies to."""
 
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="ignore", frozen=True)
 
     agency_id: str | None = None
     route_id: str | None = None
@@ -71,7 +71,7 @@ class InformedEntity(BaseModel):
 class TranslatedText(BaseModel):
     """One language variant of a translatable string."""
 
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="ignore", frozen=True)
 
     text: str
     language: str | None = None
@@ -80,7 +80,7 @@ class TranslatedText(BaseModel):
 class TranslatedString(BaseModel):
     """A GTFS-RT TranslatedString with helpers for picking a language."""
 
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="ignore", frozen=True)
 
     translation: list[TranslatedText] = []
 
@@ -94,7 +94,7 @@ class TranslatedString(BaseModel):
 class MercuryAlertExtension(BaseModel):
     """MTA's `transit_realtime.mercury_alert` extension on each alert."""
 
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="ignore", frozen=True)
 
     created_at: int | None = None
     updated_at: int | None = None
@@ -104,7 +104,7 @@ class MercuryAlertExtension(BaseModel):
 class Alert(BaseModel):
     """A single GTFS-RT service alert."""
 
-    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+    model_config = ConfigDict(extra="ignore", populate_by_name=True, frozen=True)
 
     active_period: list[TimeRange] = []
     informed_entity: list[InformedEntity] = []
@@ -135,7 +135,7 @@ class Alert(BaseModel):
 class AlertEntity(BaseModel):
     """A wrapped alert with its feed-level id."""
 
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="ignore", frozen=True)
 
     id: str
     alert: Alert
@@ -144,6 +144,6 @@ class AlertEntity(BaseModel):
 class AlertsFeed(BaseModel):
     """Top-level GTFS-RT alerts feed (JSON variant)."""
 
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="ignore", frozen=True)
 
     entity: list[AlertEntity] = []

--- a/custom_components/mta_subway/sensor.py
+++ b/custom_components/mta_subway/sensor.py
@@ -19,13 +19,15 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import CONF_LINE, DOMAIN, ICONS_BASE, SUBWAY_LINES
-from .coordinator import MTASubwayCoordinator, MTASubwayData
+from .coordinator import MTASubwayCoordinator
 from .models import Route
 
 if TYPE_CHECKING:
-    from homeassistant.config_entries import ConfigEntry
+    from . import MTASubwayConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
+
+PARALLEL_UPDATES = 0
 
 PLATFORM_SCHEMA = SENSOR_PLATFORM_SCHEMA.extend(  # pyright: ignore[reportUnknownMemberType]
     {
@@ -60,11 +62,11 @@ async def async_setup_platform(
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: MTASubwayConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up MTA Subway sensors from a config entry."""
-    data: MTASubwayData = hass.data[DOMAIN][entry.entry_id]
+    data = entry.runtime_data
     lines: list[str] = entry.options.get(CONF_LINE) or entry.data[CONF_LINE]
     entities: list[CoordinatorEntity[MTASubwayCoordinator]] = []
     for line in lines:

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,86 @@
+"""Tests for the diagnostics platform."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from aioresponses import aioresponses
+from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.mta_subway.const import (
+    ALERTS_API_URL,
+    API_URL,
+    CONF_LINE,
+    DOMAIN,
+)
+from custom_components.mta_subway.diagnostics import (
+    async_get_config_entry_diagnostics,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+ROUTES_PAYLOAD: dict[str, object] = {
+    "routes": {
+        "1": {
+            "id": "1",
+            "name": "1",
+            "color": "#ee352e",
+            "status": "Delays",
+            "scheduled": True,
+        },
+        "L": {
+            "id": "L",
+            "name": "L",
+            "color": "#a7a9ac",
+            "status": "Good Service",
+            "scheduled": True,
+        },
+    }
+}
+
+ALERTS_PAYLOAD: dict[str, object] = {
+    "header": {},
+    "entity": [
+        {
+            "id": "alert:1",
+            "alert": {
+                "active_period": [{"start": 1000000000}],
+                "informed_entity": [{"agency_id": "MTASBWY", "route_id": "1"}],
+                "header_text": {
+                    "translation": [{"text": "Delay on 1", "language": "en"}]
+                },
+                "transit_realtime.mercury_alert": {"alert_type": "Delays"},
+            },
+        }
+    ],
+}
+
+
+async def test_diagnostics_dump(hass: HomeAssistant) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_LINE: ["1", "L"]}, unique_id=DOMAIN
+    )
+    entry.add_to_hass(hass)
+    assert await async_setup_component(hass, "http", {})
+
+    with aioresponses() as mocked:
+        mocked.get(API_URL, payload=ROUTES_PAYLOAD, repeat=True)
+        mocked.get(ALERTS_API_URL, payload=ALERTS_PAYLOAD, repeat=True)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        diag = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert diag["config_entry"]["data"] == {CONF_LINE: ["1", "L"]}
+    assert diag["routes"]["last_update_success"] is True
+    assert diag["routes"]["count"] == 2
+    assert diag["routes"]["lines"] == ["1", "L"]
+    assert diag["routes"]["sample"] is not None
+    assert diag["alerts"]["last_update_success"] is True
+    assert diag["alerts"]["count"] == 1
+    assert "Delays" in diag["alerts"]["alert_types"]
+    assert diag["alerts"]["by_route"]["1"] == 1
+    assert diag["alerts"]["by_route"]["L"] == 0

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,96 @@
+"""Tests for the MTA Subway integration setup and unload."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from aioresponses import aioresponses
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.mta_subway.const import (
+    ALERTS_API_URL,
+    API_URL,
+    CONF_LINE,
+    DOMAIN,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+ROUTES_PAYLOAD: dict[str, object] = {
+    "routes": {
+        "1": {
+            "id": "1",
+            "name": "1",
+            "color": "#ee352e",
+            "status": "Good Service",
+            "scheduled": True,
+        }
+    },
+    "timestamp": 1234567890,
+}
+
+ALERTS_PAYLOAD: dict[str, object] = {"header": {}, "entity": []}
+
+
+async def test_setup_entry_loads_and_unloads(hass: HomeAssistant) -> None:
+    """Full setup-and-unload cycle uses runtime_data and creates entities."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_LINE: ["1"]},
+        unique_id=DOMAIN,
+    )
+    entry.add_to_hass(hass)
+    assert await async_setup_component(hass, "http", {})
+
+    with aioresponses() as mocked:
+        mocked.get(API_URL, payload=ROUTES_PAYLOAD, repeat=True)
+        mocked.get(ALERTS_API_URL, payload=ALERTS_PAYLOAD, repeat=True)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert entry.runtime_data is not None
+    assert entry.runtime_data.routes.data is not None
+    assert "1" in entry.runtime_data.routes.data
+
+    line_state = hass.states.get("sensor.mta_subway_1")
+    assert line_state is not None
+    assert line_state.state == "Good Service"
+
+    north_state = hass.states.get("sensor.mta_subway_1_northbound")
+    assert north_state is not None
+
+    planned_work = hass.states.get("binary_sensor.mta_subway_1_planned_work")
+    assert planned_work is not None
+    assert planned_work.state == "off"
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    assert entry.state is ConfigEntryState.NOT_LOADED
+
+
+async def test_options_change_reloads_entry(hass: HomeAssistant) -> None:
+    """Updating options triggers entry reload via update listener."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_LINE: ["1"]},
+        unique_id=DOMAIN,
+    )
+    entry.add_to_hass(hass)
+    assert await async_setup_component(hass, "http", {})
+
+    with aioresponses() as mocked:
+        mocked.get(API_URL, payload=ROUTES_PAYLOAD, repeat=True)
+        mocked.get(ALERTS_API_URL, payload=ALERTS_PAYLOAD, repeat=True)
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        hass.config_entries.async_update_entry(entry, options={CONF_LINE: ["1", "2"]})
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert hass.states.get("sensor.mta_subway_2") is not None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,87 @@
+"""Edge case tests for pydantic models."""
+
+from __future__ import annotations
+
+from custom_components.mta_subway.models import (
+    Alert,
+    AlertEntity,
+    Route,
+    TranslatedString,
+)
+
+
+def test_alert_is_active_when_no_period_specified() -> None:
+    alert = Alert.model_validate(
+        {
+            "informed_entity": [{"route_id": "1"}],
+            "transit_realtime.mercury_alert": {"alert_type": "Delays"},
+        }
+    )
+    assert alert.is_active_at(0) is True
+    assert alert.is_active_at(9_999_999_999) is True
+
+
+def test_alert_with_open_ended_active_period() -> None:
+    alert = Alert.model_validate(
+        {
+            "active_period": [{"start": 1000}],
+            "informed_entity": [{"route_id": "1"}],
+        }
+    )
+    assert alert.is_active_at(999) is False
+    assert alert.is_active_at(1000) is True
+    assert alert.is_active_at(2_000_000_000) is True
+
+
+def test_alert_with_alert_type_none_falls_through_to_service_change() -> None:
+    """Alerts without a mercury_alert extension should still parse."""
+    alert = Alert.model_validate(
+        {
+            "informed_entity": [{"route_id": "1"}],
+        }
+    )
+    assert alert.alert_type is None
+
+
+def test_translated_string_returns_none_when_no_translations() -> None:
+    ts = TranslatedString.model_validate({"translation": []})
+    assert ts.text() is None
+
+
+def test_translated_string_falls_back_to_first_when_lang_missing() -> None:
+    ts = TranslatedString.model_validate(
+        {"translation": [{"text": "Foo", "language": "es"}]}
+    )
+    assert ts.text("en") == "Foo"
+
+
+def test_route_is_frozen() -> None:
+    route = Route.model_validate(
+        {
+            "id": "1",
+            "name": "1",
+            "color": "#ee352e",
+            "status": "Good Service",
+            "scheduled": True,
+        }
+    )
+    try:
+        route.status = "Mutated"  # type: ignore[misc]
+    except (TypeError, ValueError):
+        return
+    msg = "Route should be frozen"
+    raise AssertionError(msg)
+
+
+def test_alert_entity_round_trips() -> None:
+    payload = {
+        "id": "alert:1",
+        "alert": {
+            "informed_entity": [{"route_id": "1"}],
+            "header_text": {"translation": [{"text": "Hi", "language": "en"}]},
+        },
+    }
+    entity = AlertEntity.model_validate(payload)
+    assert entity.id == "alert:1"
+    assert entity.alert.affects_route("1")
+    assert not entity.alert.affects_route("2")


### PR DESCRIPTION
- pydantic models now frozen so parsed API data can't be mutated
- per-line and alert binary sensors declare unbounded parallel updates
- moved per-entry state from hass.data to entry.runtime_data (modern HA pattern)
- new diagnostics platform exposes coordinator state and last errors for debugging
- end-to-end tests for setup, options reload, and diagnostics
- pushed coverage from 89% to 97%