### PR TITLE
wire up Codecov Test Analytics

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,9 +44,16 @@ jobs:
       - run: uv sync
       - run: uv run pytest
       - name: Upload coverage to Codecov
+        if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v6
         with:
           files: ./coverage.xml
           fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./junit.xml

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 .coverage
 coverage.xml
 htmlcov/
+junit.xml
 
 # Local tooling (not for upstream)
 AGENTS.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ reportPrivateUsage = "none"
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
-addopts = "-ra -q --cov=custom_components.mta_subway --cov-report=term --cov-report=xml"
+addopts = "-ra -q --cov=custom_components.mta_subway --cov-report=term --cov-report=xml --junitxml=junit.xml -o junit_family=legacy"
 
 [tool.coverage.run]
 source = ["custom_components/mta_subway"]


### PR DESCRIPTION
- emit JUnit XML from pytest
- upload test results via codecov/test-results-action so the dashboard surfaces flaky tests and failure trends
- gate the existing coverage upload on !cancelled() so it runs even when tests fail