### PR TITLE
modernize config-entry patterns

### DIFF
--- a/custom_components/mta_subway/config_flow.py
+++ b/custom_components/mta_subway/config_flow.py
@@ -42,9 +42,6 @@ class MTASubwayConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        await self.async_set_unique_id(DOMAIN)
-        self._abort_if_unique_id_configured()
-
         if user_input is None:
             return self.async_show_form(
                 step_id="user",
@@ -53,8 +50,6 @@ class MTASubwayConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_create_entry(title="MTA Subway", data=user_input)
 
     async def async_step_import(self, import_data: dict[str, Any]) -> ConfigFlowResult:
-        await self.async_set_unique_id(DOMAIN)
-        self._abort_if_unique_id_configured()
         return self.async_create_entry(title="MTA Subway", data=import_data)
 
     @staticmethod

--- a/custom_components/mta_subway/coordinator.py
+++ b/custom_components/mta_subway/coordinator.py
@@ -52,6 +52,8 @@ class MTASubwayCoordinator(DataUpdateCoordinator[dict[str, Route]]):
 
         if not parsed.routes:
             raise UpdateFailed("Response contained no routes")
+        if parsed.routes == self.data:
+            return self.data
         return parsed.routes
 
 
@@ -82,6 +84,8 @@ class MTAAlertsCoordinator(DataUpdateCoordinator[list[AlertEntity]]):
         except ValidationError as err:
             raise UpdateFailed(f"Invalid alerts response: {err}") from err
 
+        if parsed.entity == self.data:
+            return self.data
         return parsed.entity
 
 

--- a/custom_components/mta_subway/manifest.json
+++ b/custom_components/mta_subway/manifest.json
@@ -9,5 +9,6 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/iicky/homeassistant-mta-subway/issues",
     "requirements": ["pydantic>=2.6"],
+    "single_config_entry": true,
     "version": "0.4.0"
 }

--- a/tests/test_alerts_coordinator.py
+++ b/tests/test_alerts_coordinator.py
@@ -71,6 +71,18 @@ async def test_alerts_http_error(hass: HomeAssistant) -> None:
     assert isinstance(coordinator.last_exception, UpdateFailed)
 
 
+async def test_alerts_unchanged_returns_same_instance(hass: HomeAssistant) -> None:
+    """Equal payloads short-circuit so coordinator.data identity is preserved."""
+    coordinator = MTAAlertsCoordinator(hass)
+    with aioresponses() as mocked:
+        mocked.get(ALERTS_API_URL, payload=SAMPLE_ALERTS_PAYLOAD, repeat=True)
+        await coordinator.async_refresh()
+        first = coordinator.data
+        await coordinator.async_refresh()
+
+    assert coordinator.data is first
+
+
 async def test_alerts_empty_feed(hass: HomeAssistant) -> None:
     coordinator = MTAAlertsCoordinator(hass)
     with aioresponses() as mocked:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -40,15 +40,13 @@ async def test_user_flow_creates_entry(hass: HomeAssistant) -> None:
 
 
 async def test_already_configured_aborts(hass: HomeAssistant) -> None:
-    MockConfigEntry(
-        domain=DOMAIN, data={CONF_LINE: ["1"]}, unique_id=DOMAIN
-    ).add_to_hass(hass)
+    MockConfigEntry(domain=DOMAIN, data={CONF_LINE: ["1"]}).add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] == FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
+    assert result["reason"] == "single_instance_allowed"
 
 
 async def test_yaml_import_creates_entry(hass: HomeAssistant) -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -48,6 +48,18 @@ async def test_update_data_http_error(hass: HomeAssistant) -> None:
     assert isinstance(coordinator.last_exception, UpdateFailed)
 
 
+async def test_update_data_unchanged_returns_same_instance(hass: HomeAssistant) -> None:
+    """Equal payloads short-circuit so coordinator.data identity is preserved."""
+    coordinator = MTASubwayCoordinator(hass)
+    with aioresponses() as mocked:
+        mocked.get(API_URL, payload=SAMPLE_PAYLOAD, repeat=True)  # pyright: ignore[reportUnknownMemberType]
+        await coordinator.async_refresh()
+        first = coordinator.data
+        await coordinator.async_refresh()
+
+    assert coordinator.data is first
+
+
 async def test_update_data_missing_routes(hass: HomeAssistant) -> None:
     coordinator = MTASubwayCoordinator(hass)
     with aioresponses() as mocked:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -73,6 +73,25 @@ async def test_setup_entry_loads_and_unloads(hass: HomeAssistant) -> None:
     assert entry.state is ConfigEntryState.NOT_LOADED
 
 
+async def test_setup_fails_when_routes_feed_unreachable(hass: HomeAssistant) -> None:
+    """Setup raises ConfigEntryNotReady when the routes feed errors on first refresh."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_LINE: ["1"]},
+        unique_id=DOMAIN,
+    )
+    entry.add_to_hass(hass)
+    assert await async_setup_component(hass, "http", {})
+
+    with aioresponses() as mocked:
+        mocked.get(API_URL, status=500, repeat=True)
+        mocked.get(ALERTS_API_URL, payload=ALERTS_PAYLOAD, repeat=True)
+        assert not await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+
+
 async def test_options_change_reloads_entry(hass: HomeAssistant) -> None:
     """Updating options triggers entry reload via update listener."""
     entry = MockConfigEntry(


### PR DESCRIPTION
- enforce single-instance via manifest single_config_entry instead of hand-rolled unique_id check
- short-circuit coordinator data when feed payload is unchanged
- add a setup-failure test covering routes-feed unreachable